### PR TITLE
Turn on the risk effect for vitamin A

### DIFF
--- a/src/vivarium_gates_lsff/model_specifications/model_spec.in
+++ b/src/vivarium_gates_lsff/model_specifications/model_spec.in
@@ -7,6 +7,9 @@ components:
         disease.models:
             - SIS('diarrheal_diseases')
             - SIS_fixed_duration('measles', '10')
+        risks:
+            - RiskEffect('risk_factor.vitamin_a_deficiency', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.vitamin_a_deficiency', 'cause.measles.incidence_rate')
         metrics:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')


### PR DESCRIPTION
Results of interactive sim show greater disability weights in the vitamin A deficient group:
```
# Number of vitamin A simulants
In [13]: va_def.sum()
Out[13]: 1812

In [14]: va_adequate = ~va_def

In [15]: va_adequate.sum()
Out[15]: 8230

# Disability weight for vitamin A simulants is higher than non-deficient simulants
In [16]: p_dw(pop.index)[va_def].mean()
Out[16]: 0.0024893061581517805

In [17]: p_dw(pop.index)[va_adequate].mean()
Out[17]: 0.0019420121302273466

# More detail
In [18]: p_dw(pop.index)[va_def].describe()
Out[18]:
count    1812.000000
mean        0.002489
std         0.004620
min         0.000000
25%         0.000538
50%         0.000623
75%         0.000623
max         0.013797
dtype: float64

In [19]: p_dw(pop.index)[va_adequate].describe()
Out[19]:
count    8230.000000
mean        0.001942
std         0.004692
min         0.000000
25%         0.000000
50%         0.000000
75%         0.000000
max         0.021672
dtype: float64

```