### PR TITLE
These changes make our distribution match a distribution from R code …

### DIFF
--- a/src/vivarium_gates_lsff/components/disease/iron_deficiency.py
+++ b/src/vivarium_gates_lsff/components/disease/iron_deficiency.py
@@ -203,9 +203,11 @@ class IronDeficiencyDistribution:
     @staticmethod
     def _mirrored_gumbel_ppf(propensity, mean, sd):
         x_max = data_values.HEMOGLOBIN_DISTRIBUTION.EXPOSURE_MAX
-        alpha = x_max - mean - (sd * np.euler_gamma * np.sqrt(6) / np.pi)
+        _alpha = x_max - mean - (sd * np.euler_gamma * np.sqrt(6) / np.pi)
         scale = sd * np.sqrt(6) / np.pi
-        return x_max - scipy.stats.gumbel_r(alpha, scale=scale).ppf(1 - propensity)
+        tmp = _alpha + (scale*np.euler_gamma)
+        alpha = _alpha + x_max - (2*tmp)
+        return scipy.stats.gumbel_r(alpha, scale=scale).ppf(propensity)
 
     @staticmethod
     def load_exposure_parameters(builder):


### PR DESCRIPTION
…which matches GBD.
```

print(f'R gumbel overview:\n{rdf_gum.describe()}')
print(f'Python gumbel overview:\n{gum_vals.describe()}')
R gumbel overview:
            gvalues
count  10000.000000
mean     120.293465
std       15.061654
min       86.878132
25%      109.714645
50%      117.890049
75%      128.282924
max      243.116532
Python gumbel overview:
count    10000.000000
mean       120.293467
std         15.061654
min         86.878134
25%        109.714647
50%        117.890051
75%        128.282926
max        243.116534
```